### PR TITLE
Refactor TripDetailView chart for type-checking

### DIFF
--- a/bumperHunter/Views/TripDetailView.swift
+++ b/bumperHunter/Views/TripDetailView.swift
@@ -17,12 +17,16 @@ struct TripDetailView: View {
     var body: some View {
         VStack {
             Chart {
-                ForEach(Array(cumulativeData.enumerated()), id: \.offset) { index, item in
+                ForEach(cumulativeData.indices, id: \.self) { index in
+                    let item = cumulativeData[index]
                     LineMark(
                         x: .value("Time", item.0),
                         y: .value("Count", item.1)
                     )
-                    if showPercentage {
+                }
+                if showPercentage {
+                    ForEach(cumulativeData.indices, id: \.self) { index in
+                        let item = cumulativeData[index]
                         LineMark(
                             x: .value("Time", item.0),
                             y: .value("Percent", Double(item.1) / Double(trip.totalCount))


### PR DESCRIPTION
## Summary
- Refactor TripDetailView chart rendering to use separate loops for count and percentage lines.
- Simplify the Chart's data iteration to improve compiler type-checking.

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a31a70188331b2f110d246da2b5d