### PR TITLE
Simplify TripDetailView data iteration

### DIFF
--- a/bumperHunter/Views/TripDetailView.swift
+++ b/bumperHunter/Views/TripDetailView.swift
@@ -15,16 +15,17 @@ struct TripDetailView: View {
     }
 
     var body: some View {
-        VStack {
+        let data = Array(cumulativeData.enumerated())
+        return VStack {
             Chart {
-                ForEach(Array(cumulativeData.enumerated()), id: \.offset) { _, item in
+                ForEach(data, id: \.offset) { _, item in
                     LineMark(
                         x: .value("Time", item.0),
                         y: .value("Count", item.1)
                     )
                 }
                 if showPercentage {
-                    ForEach(Array(cumulativeData.enumerated()), id: \.offset) { _, item in
+                    ForEach(data, id: \.offset) { _, item in
                         LineMark(
                             x: .value("Time", item.0),
                             y: .value("Percent", Double(item.1) / Double(trip.totalCount))


### PR DESCRIPTION
## Summary
- refactor `TripDetailView` to precompute enumerated chart data

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a572b3108331877208a4c25668fb